### PR TITLE
QuickPanel: Increase minimum brightness to 10 as in settings.

### DIFF
--- a/src/qml/quickpanel/QuickPanel.qml
+++ b/src/qml/quickpanel/QuickPanel.qml
@@ -690,14 +690,8 @@ Component {
         QuickPanelToggle {
             id: brightnessToggle
             icon: "ios-sunny"
-            onChecked: {
-                if (displaySettings.brightness === 0) {
-                    displaySettings.brightness = 100
-                } else if (displaySettings.brightness < 100) {
-                    displaySettings.brightness = 100
-                }
-            }
-            onUnchecked: displaySettings.brightness = 0
+            onChecked: displaySettings.brightness = 100
+            onUnchecked: displaySettings.brightness = 10
             Component.onCompleted: toggled = displaySettings.brightness > 10
 
             property bool isIncreasing: true // Current direction for adjustment


### PR DESCRIPTION
src/qml/quickpanel/QuickPanel.qml
(rootitem.brightnessToggle.onUnchecked): Set displaySettings.brightness to 10 instead of 0, matching the minimum value in the asteroid-settings app. Setting this to 0 leads to an unusable completely black screen on some hardware, e.g., LG G Watch R (lenok).
(rootitem.brightnessToggle.onChecked): Simplify the code to eliminate redundant conditionals.

Fixes #182.